### PR TITLE
Add keybinds hold option

### DIFF
--- a/src/main/java/co/bugg/quickplay/config/ConfigSettings.java
+++ b/src/main/java/co/bugg/quickplay/config/ConfigSettings.java
@@ -212,6 +212,17 @@ public class ConfigSettings extends AConfiguration implements Serializable {
     public transient final Runnable editKeybinds = () -> Minecraft.getMinecraft().displayGuiScreen(new QuickplayGuiKeybinds());
 
     /**
+     * Opacity of the instance display
+     */
+    @GuiOption(
+            name = "quickplay.settings.keybindPressTime.name",
+            helpText = "quickplay.settings.keybindPressTime.help",
+            minValue = 0.0f,
+            maxValue = 3.0f
+    )
+    public double keybindPressTime = 0.0;
+
+    /**
      * Whether the client should swap to lobby one when it joins a new lobby
      */
     @GuiOption(

--- a/src/main/java/co/bugg/quickplay/config/ConfigSettings.java
+++ b/src/main/java/co/bugg/quickplay/config/ConfigSettings.java
@@ -220,7 +220,7 @@ public class ConfigSettings extends AConfiguration implements Serializable {
             minValue = 0.0f,
             maxValue = 3.0f
     )
-    public double keybindPressTime = 0.0;
+    public double keybindPressTime = 0.5;
 
     /**
      * Whether the client should swap to lobby one when it joins a new lobby

--- a/src/main/resources/assets/quickplay/lang/en_US.lang
+++ b/src/main/resources/assets/quickplay/lang/en_US.lang
@@ -100,6 +100,8 @@ quickplay.settings.sendUsageStatsButton.name=Usage Statistics...
 quickplay.settings.sendUsageStatsButton.help=Send anonymous usage statistics to help me create better mods for you!
 quickplay.settings.editKeybinds.name=Edit Keybinds...
 quickplay.settings.editKeybinds.help=Assign & remove keybinds previously created by right-clicking games or modes.
+quickplay.settings.keybindPressTime.name=Keybind Press Duration
+quickplay.settings.keybindPressTime.help=How long you have to hold keybinds which have holding enabled for them to activate.
 quickplay.settings.lobbyOneSwap.name=Swap to Lobby One
 quickplay.settings.lobbyOneSwap.help=Swap to lobby one automatically whenever you join a new lobby.
 quickplay.settings.updateNotifications.name=Update Notifications
@@ -164,6 +166,7 @@ quickplay.keybinds.illegal=The keybind "%s" is invalid for some reason! Try recr
 quickplay.keybinds.title=Keybinds
 quickplay.keybinds.reset=Reset Keybinds
 quickplay.gui.keybinds.delete=Delete
+quickplay.gui.keybinds.requireHolding=Holding required: %s
 quickplay.gui.keybinds.taken=That key is already assigned to a Quickplay function!
 
 quickplay.moveableHudElement.small=SMALL


### PR DESCRIPTION
Add a config setting allowing users to require keybinds to be held to activate. Default is not enabled for any keybinds, with a default hold time of 0.5 seconds. Right-click keybinds to enable, and length can be anywhere from 0 to 3 seconds.
This closes issue #52