### PR TITLE
Fixed issue with keybinds running when they shouldn't be able to

### DIFF
--- a/src/main/java/co/bugg/quickplay/client/QuickplayKeybind.java
+++ b/src/main/java/co/bugg/quickplay/client/QuickplayKeybind.java
@@ -185,6 +185,10 @@ public class QuickplayKeybind implements Serializable, GsonPostProcessorFactory.
 
     @SubscribeEvent
     public void onKeyPress(InputEvent.KeyInputEvent event) {
+        // Keybinds only work On Hypixel and if Quickplay is enabled.
+        if(!Quickplay.INSTANCE.checkEnabledStatus() || !Quickplay.INSTANCE.onHypixel) {
+            return;
+        }
         if(key != Keyboard.KEY_NONE && Keyboard.isKeyDown(key)) {
             int currentPressCount = ++this.pressCount;
             Quickplay.INSTANCE.threadPool.submit(() -> {


### PR DESCRIPTION
Keybinds will no longer run if the user is not online Hypixel or Quickplay is disabled.
Closes #66 