### PR TITLE
Fixed Glyph modification crash

### DIFF
--- a/src/main/java/co/bugg/quickplay/Quickplay.java
+++ b/src/main/java/co/bugg/quickplay/Quickplay.java
@@ -308,8 +308,10 @@ public class Quickplay {
                                 }
                                 // Add all glyphs
                                 if(response.content.getAsJsonObject().get("glyphs") != null) {
-                                    glyphs.addAll(Arrays.asList(new Gson().fromJson(response.content
-                                            .getAsJsonObject().get("glyphs"), PlayerGlyph[].class)));
+                                    QuickplayEventHandler.mainThreadScheduledTasks.add(() -> {
+                                        glyphs.addAll(Arrays.asList(new Gson().fromJson(response.content
+                                                .getAsJsonObject().get("glyphs"), PlayerGlyph[].class)));
+                                    });
                                 }
                             }
                         } catch (IllegalStateException e) {

--- a/src/main/java/co/bugg/quickplay/client/command/premium/glyph/GlyphCommand.java
+++ b/src/main/java/co/bugg/quickplay/client/command/premium/glyph/GlyphCommand.java
@@ -1,6 +1,7 @@
 package co.bugg.quickplay.client.command.premium.glyph;
 
 import co.bugg.quickplay.Quickplay;
+import co.bugg.quickplay.QuickplayEventHandler;
 import co.bugg.quickplay.client.command.ACommand;
 import co.bugg.quickplay.client.render.PlayerGlyph;
 import co.bugg.quickplay.http.Request;
@@ -60,8 +61,10 @@ public abstract class GlyphCommand extends ACommand {
                                 glyphsToRemove.add(glyph);
                             }
                         }
-                        glyphs.removeAll(glyphsToRemove);
-                        glyphs.add(newGlyph);
+                        QuickplayEventHandler.mainThreadScheduledTasks.add(() -> {
+                            glyphs.removeAll(glyphsToRemove);
+                            glyphs.add(newGlyph);
+                        });
 
                     } catch(JsonSyntaxException e) {
                         e.printStackTrace();


### PR DESCRIPTION
The glyph list is now modified on the main thread pre-render, preventing ConcurrentModificationException.
This closes #90 