### PR TITLE
Improved Glyphs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ jar {
 
 targetCompatibility = sourceCompatibility = 1.8
 
-version = "2.1.0-beta2"
+version = "2.1.0-beta3"
 group= "co.bugg.quickplay" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Quickplay-1.8.9"
 

--- a/src/main/java/co/bugg/quickplay/Reference.java
+++ b/src/main/java/co/bugg/quickplay/Reference.java
@@ -15,7 +15,7 @@ public class Reference {
     /**
      * Version of this forge mod
      */
-    public static final String VERSION = "2.1.0-beta2";
+    public static final String VERSION = "2.1.0-beta3";
     /**
      * Google Analytics tracking ID
      */

--- a/src/main/java/co/bugg/quickplay/client/gui/animations/Animation.java
+++ b/src/main/java/co/bugg/quickplay/client/gui/animations/Animation.java
@@ -80,7 +80,6 @@ public class Animation {
      * @return This
      */
     public synchronized Animation updateFrame() {
-        // If started
         if(started) {
             final long now = System.currentTimeMillis();
 
@@ -88,7 +87,9 @@ public class Animation {
                 progress = 0;
             } else if(startedMillis + length > now) {
                 progress = ((float) (now - startedMillis)) / (float) length;
-            } else progress = 1;
+            } else {
+                progress = 1;
+            }
 
         } else throw new IllegalStateException("This animation has not been started yet. You must call start() first.");
 

--- a/src/main/java/co/bugg/quickplay/client/render/GlyphRenderer.java
+++ b/src/main/java/co/bugg/quickplay/client/render/GlyphRenderer.java
@@ -2,13 +2,14 @@ package co.bugg.quickplay.client.render;
 
 import co.bugg.quickplay.Quickplay;
 import co.bugg.quickplay.Reference;
+import co.bugg.quickplay.client.gui.animations.Animation;
 import com.google.common.hash.Hashing;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiInventory;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
-import net.minecraft.client.renderer.entity.RendererLivingEntity;
+import net.minecraft.client.renderer.entity.RenderPlayer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
@@ -17,8 +18,10 @@ import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.lwjgl.opengl.GL11;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Renders all Quickplay Glyphs when registered to the event bus
@@ -39,46 +42,118 @@ public class GlyphRenderer {
      */
     public static final Pattern gameServerPattern = Pattern.compile("^(?:mini|mega)[0-9]{1,3}[A-Z]$");
 
-    @SubscribeEvent
-    public void onPlayerRender(RenderPlayerEvent.Pre e) {
+    /**
+     * Animation list for each player with a glyph and their glyph's opacity.
+     * This is used to determine glyph opacity from fading due to proximity.
+     */
+    private final Map<UUID, Animation> opacityAnimations = new HashMap<>();
+    /**
+     * The distance to the client that the player which the UUID key belongs to was last frame.
+     * This is used in determining when to start a fade animation due to proximity.
+     */
+    private final Map<UUID, Double> prevDistance = new HashMap<>();
 
-        final String currentServer = Quickplay.INSTANCE.instanceWatcher.getCurrentServer();
+    @SubscribeEvent
+    public void onPlayerRender(RenderPlayerEvent.Post e) {
         // Don't render at all if F1 is hit or if the client is in a game (or unknown location)
         if(!Minecraft.getMinecraft().gameSettings.hideGUI) {
-            final EntityPlayer player = e.entityPlayer;
+            final String currentServer = Quickplay.INSTANCE.instanceWatcher.getCurrentServer();
             final EntityPlayer self = Minecraft.getMinecraft().thePlayer;
+            final EntityPlayer player = e.entityPlayer;
 
-            // If both players aren't null, player is visible, and player isn't dead
-            if (player != null && self != null && !player.isInvisible() && !player.isDead && !player.isSneaking() && self.canEntityBeSeen(player) && self.getDistanceSqToEntity(player) < drawDistance * drawDistance) {
-                // If not rendering self or inventory isn't open (don't render self while inventory is open)
-                if(player != self || !(Minecraft.getMinecraft().currentScreen instanceof GuiInventory)) {
-                    // If the player being rendered isn't this player OR the client's settings allow rendering of own glyph
-                    if (!player.getUniqueID().toString().equals(self.getUniqueID().toString()) || Quickplay.INSTANCE.settings.displayOwnGlyph) {
-                        // If the player has any glyphs
-                        if (Quickplay.INSTANCE.glyphs.stream().anyMatch(glyph -> glyph.uuid.toString().equals(player.getUniqueID().toString()))) {
-                            final PlayerGlyph glyph = Quickplay.INSTANCE.glyphs.stream().filter(thisGlyph -> thisGlyph.uuid.equals(player.getGameProfile().getId())).collect(Collectors.toList()).get(0);
-                            // If this client is currently not in a game OR if the glyph is set to display in-game
-                            if ((currentServer != null && !gameServerPattern.matcher(currentServer).matches()) || glyph.displayInGames) {
-                                renderGlyph(e.renderer, glyph, e.entityPlayer, e.x, e.y + offset + player.height, e.z);
-                            }
-                        }
-                    }
+            // Stop if either player is null
+            if (player == null || self == null) {
+                return;
+            }
+
+            // Stop if client user cannot see the player/the player's name
+            if (player.isInvisibleToPlayer(self) || player.isDead || player.isSneaking() || !self.canEntityBeSeen(player)) {
+                return;
+            }
+            // Stop if the player is farther than the draw distance of glyphs
+            if (self.getDistanceSqToEntity(player) > GlyphRenderer.drawDistance * GlyphRenderer.drawDistance) {
+                return;
+            }
+            // Stop if we're rendering the client player, and they have their inventory open. Otherwise the glyph
+            // appears in the inventory.
+            if (player == self && Minecraft.getMinecraft().currentScreen instanceof GuiInventory) {
+                return;
+            }
+            // Stop if the client user has disabled rendering their own glyph, and we're rendering the client user.
+            if (player.getUniqueID().toString().equals(self.getUniqueID().toString()) && !Quickplay.INSTANCE.settings.displayOwnGlyph) {
+                return;
+            }
+
+            for (PlayerGlyph glyph : Quickplay.INSTANCE.glyphs) {
+                if (!glyph.uuid.toString().equals(player.getUniqueID().toString())) {
+                    continue;
                 }
+                // Don't display glyph if the glyph owner has disabled displaying the glyph in-game.
+                if (currentServer == null || (gameServerPattern.matcher(currentServer).matches() && !glyph.displayInGames)) {
+                    return;
+                }
+                float opacity = 1.0f;
+                if (!player.getUniqueID().toString().equals(self.getUniqueID().toString())) {
+                    double xDist = Math.abs(player.posX - self.posX);
+                    double yDist = Math.abs(player.posY - self.posY);
+                    double zDist = Math.abs(player.posZ - self.posZ);
+                    double pythagorean = Math.sqrt(Math.pow(xDist, 2) + Math.pow(yDist, 2) + Math.pow(zDist, 2));
+
+                    opacity = this.calcOpacityForPlayer(player, pythagorean,
+                            gameServerPattern.matcher(currentServer).matches() ? 8 : 4);
+                }
+                renderGlyph(e.renderer, glyph, e.x, e.y + offset + player.height, e.z, opacity);
             }
 
         }
     }
 
     /**
+     * Calculate the opacity of a glyph for a specified user at a specified distance.
+     * @param player The target player.
+     * @param dist The distance the target player is from the client player.
+     * @param horizon The "horizon point" at which glyphs should appear/disappear.
+     */
+    private float calcOpacityForPlayer(EntityPlayer player, double dist, double horizon) {
+        final int animationMillis = 200;
+        final UUID uuid = player.getGameProfile().getId();
+        Animation currentAnim = this.opacityAnimations.get(uuid);
+        final Double prevDistance = this.prevDistance.get(uuid);
+        float opacity;
+
+        // If either animation or previous distance are null, OR if the player has crossed the distance horizon since last frame
+        if(currentAnim == null || prevDistance == null ||
+                (prevDistance <= horizon && dist > horizon) || (prevDistance > horizon && dist <= horizon)) {
+            currentAnim = new Animation(animationMillis);
+            this.opacityAnimations.put(uuid, currentAnim);
+            Quickplay.INSTANCE.threadPool.submit(currentAnim::start);
+        }
+        // Since the animation is started in a separate thread, it might not have started yet for one or two frames.
+        if(currentAnim.started) {
+            currentAnim.updateFrame();
+            opacity = (float) currentAnim.progress;
+        } else {
+            opacity = 0.0f;
+        }
+
+        // Flip opacity if the user is within the horizon distance
+        if(dist <= horizon) {
+            opacity = 1 - opacity;
+        }
+        this.prevDistance.put(uuid, dist);
+        return opacity;
+    }
+
+    /**
      * Render a glyph
      * @param renderer Renderer to use
      * @param glyph Glyph to render
-     * @param player Player to render it over
      * @param x x position
      * @param y y position
      * @param z z position
+     * @param opacity Opacity to render the glyph at
      */
-    public synchronized void renderGlyph(RendererLivingEntity renderer, PlayerGlyph glyph, EntityPlayer player, double x, double y, double z) {
+    public synchronized void renderGlyph(RenderPlayer renderer, PlayerGlyph glyph, double x, double y, double z, float opacity) {
 
         final ResourceLocation resource = new ResourceLocation(Reference.MOD_ID, "glyphs/" +
                 Hashing.md5().hashString(glyph.path.toString(), StandardCharsets.UTF_8).toString() + ".png");
@@ -107,6 +182,9 @@ public class GlyphRenderer {
             // Scale
             GlStateManager.scale(-scale, -scale, scale);
 
+            // Opacity
+            GlStateManager.color(1, 1, 1, opacity);
+
             // Draw texture
             Tessellator tessellator = Tessellator.getInstance();
             WorldRenderer worldrenderer = tessellator.getWorldRenderer();
@@ -117,6 +195,9 @@ public class GlyphRenderer {
             worldrenderer.pos(16, 16, 0.0D).tex(1, 1).endVertex();
             worldrenderer.pos(16, -16, 0.0D).tex(1, 0).endVertex();
             tessellator.draw();
+
+            GlStateManager.color(1,1,1,1);
+            GlStateManager.scale(1/-scale, 1/-scale, 1/scale);
 
             // Remove GL properties
             GlStateManager.enableLighting();

--- a/src/main/java/co/bugg/quickplay/client/render/GlyphRenderer.java
+++ b/src/main/java/co/bugg/quickplay/client/render/GlyphRenderer.java
@@ -55,8 +55,8 @@ public class GlyphRenderer {
 
     @SubscribeEvent
     public void onPlayerRender(RenderPlayerEvent.Post e) {
-        // Don't render at all if F1 is hit or if the client is in a game (or unknown location)
-        if(!Minecraft.getMinecraft().gameSettings.hideGUI) {
+        // Don't render at all if F1 is hit and the user has showing in F1 disabled
+        if(!Minecraft.getMinecraft().gameSettings.hideGUI || Quickplay.INSTANCE.settings.showGlyphsInF1) {
             final String currentServer = Quickplay.INSTANCE.instanceWatcher.getCurrentServer();
             final EntityPlayer self = Minecraft.getMinecraft().thePlayer;
             final EntityPlayer player = e.entityPlayer;
@@ -93,7 +93,8 @@ public class GlyphRenderer {
                     return;
                 }
                 float opacity = 1.0f;
-                if (!player.getUniqueID().toString().equals(self.getUniqueID().toString())) {
+                // If the user has glyph fading enabled, and we're not talking about the same user as the client, then fade
+                if (Quickplay.INSTANCE.settings.fadeGlyphs && !player.getUniqueID().toString().equals(self.getUniqueID().toString())) {
                     double xDist = Math.abs(player.posX - self.posX);
                     double yDist = Math.abs(player.posY - self.posY);
                     double zDist = Math.abs(player.posZ - self.posZ);

--- a/src/main/java/co/bugg/quickplay/config/ConfigSettings.java
+++ b/src/main/java/co/bugg/quickplay/config/ConfigSettings.java
@@ -274,14 +274,24 @@ public class ConfigSettings extends AConfiguration implements Serializable {
     public boolean partyModeGui = true;
 
     /**
-     * Whether the user's daily reward should be displayed in-game rather than in-browser
+     * Whether a user's glyph should fade as you get closer to them.
      */
     @GuiOption(
-            name = "quickplay.settings.ingameDailyReward.name",
-            helpText = "quickplay.settings.ingameDailyReward.help",
+            name = "quickplay.settings.fadeGlyphs.name",
+            helpText = "quickplay.settings.fadeGlyphs.help",
             category = "quickplay.settings.category.premium"
     )
-    public boolean ingameDailyReward = true;
+    public boolean fadeGlyphs = true;
+
+    /**
+     * Whether a glyphs should be visible when in F1 mode.
+     */
+    @GuiOption(
+            name = "quickplay.settings.showGlyphsInF1.name",
+            helpText = "quickplay.settings.showGlyphsInF1.help",
+            category = "quickplay.settings.category.premium"
+    )
+    public boolean showGlyphsInF1 = false;
 
     /**
      * Whether the client's own glyph should be visible or not
@@ -293,6 +303,17 @@ public class ConfigSettings extends AConfiguration implements Serializable {
             category = "quickplay.settings.category.premium"
     )
     public boolean displayOwnGlyph = true;
+
+    /**
+     * Whether the user's daily reward should be displayed in-game rather than in-browser
+     */
+    @GuiOption(
+            name = "quickplay.settings.ingameDailyReward.name",
+            helpText = "quickplay.settings.ingameDailyReward.help",
+            category = "quickplay.settings.category.premium"
+    )
+    public boolean ingameDailyReward = true;
+
 
     /**
      * Allows users to change how much padding is on the

--- a/src/main/resources/assets/quickplay/lang/en_US.lang
+++ b/src/main/resources/assets/quickplay/lang/en_US.lang
@@ -116,10 +116,14 @@ quickplay.settings.partyModeGui.name=Launch Randomization GUI
 quickplay.settings.partyModeGui.help=Whether a special spinner GUI should be opened when the user launches party mode.
 
 quickplay.settings.category.premium=Premium Features
-quickplay.settings.ingameDailyReward.name=Ingame Daily Reward
-quickplay.settings.ingameDailyReward.help=Whether the handling of Daily Rewards should be in-game rather than in-browser, so you don't have to open a web page.
+quickplay.settings.fadeGlyphs.name=Fade Other Users' Glyphs
+quickplay.settings.fadeGlyphs.help=Whether other users' Glyphs should fade as you get closer to them. The fade distance is further in games vs. in lobbies.
+quickplay.settings.showGlyphsInF1.name=Show Glyphs in F1
+quickplay.settings.showGlyphsInF1.help=Whether Glyphs should be visible when you're in F1 mode.
 quickplay.settings.displayOwnGlyph.name=Display Own Glyph
 quickplay.settings.displayOwnGlyph.help=Whether your own Glyph should be displayed over your head in F5 mode.
+quickplay.settings.ingameDailyReward.name=Ingame Daily Reward
+quickplay.settings.ingameDailyReward.help=Whether the handling of Daily Rewards should be in-game rather than in-browser, so you don't have to open a web page.
 quickplay.config.keybinds.openmain=Open Main GUI
 quickplay.config.saveerror=There was an error saving your configuration. Settings may not be saved!
 quickplay.config.gui.title=Quickplay Config


### PR DESCRIPTION
* Added ability to display Glyphs in-game!
  * Enabled for all Glyphs by default. (server-side)
* Glyphs will now fade out as you get close to a player.
  * Glyphs will fade out when you are within 4 blocks in a lobby, or 8 blocks in a game.
  * Glyph fading can be toggled in `/qp config`.
* Added the ability to keep Glyphs visible even when in F1 mode.

Closes #92 